### PR TITLE
Move capnp::text::Reader to a wrapper of data::Reader

### DIFF
--- a/capnp/src/schema.rs
+++ b/capnp/src/schema.rs
@@ -3,13 +3,13 @@
 #[cfg(feature = "alloc")]
 use alloc::string::ToString;
 
-use crate::dynamic_value;
 use crate::introspect::{self, RawBrandedStructSchema, RawEnumSchema};
 use crate::private::layout;
 use crate::schema_capnp::{annotation, enumerant, field, node};
 use crate::struct_list;
 use crate::traits::{IndexMove, ListIter, ShortListIter};
 use crate::Result;
+use crate::{dynamic_value, text};
 
 /// A struct node, with generics applied.
 #[derive(Clone, Copy)]
@@ -61,7 +61,7 @@ impl StructSchema {
     /// Looks up a field by name. Returns `None` if no matching field is found.
     pub fn find_field_by_name(&self, name: &str) -> Result<Option<Field>> {
         for field in self.get_fields()? {
-            if field.get_proto().get_name()? == name {
+            if text::from_utf8(field.get_proto().get_name()?)? == name {
                 return Ok(Some(field));
             }
         }


### PR DESCRIPTION
**First commit**
This changes the `capnp::text::Reader` from a `&str` to a wrapper around
`data::Reader`, which only holds bytes.
This has the benefits of:
- Moving the conversion to `&str` and the associated utf8 check only when
  necessary, which can be a performance improvement in some cases.
- Allowing to support broken Text fields that may not hold valid UTF-8.

This is also however a breaking change as it forces to use `text::from_utf8`
to actually cast the bytes to `&str` instead of directly having `&str`.
Follows the same convention as https://doc.rust-lang.org/std/str/fn.from_utf8.html

**Second commit**
Code generator update with new text::Reader wrapper
The `text::Reader` wrapper around `data::Reader` requires us to explicitely use the
conversion to `&str`.