### PR TITLE
Make text::Reader a wrapper around data::Reader instead of &str

### DIFF
--- a/capnp-rpc/examples/pubsub/client.rs
+++ b/capnp-rpc/examples/pubsub/client.rs
@@ -35,7 +35,7 @@ impl subscriber::Server<::capnp::text::Owned> for SubscriberImpl {
     ) -> Promise<(), ::capnp::Error> {
         println!(
             "message from publisher: {}",
-            pry!(pry!(params.get()).get_message())
+            pry!(pry!(pry!(params.get()).get_message()).to_str())
         );
         Promise::ok(())
     }

--- a/capnp-rpc/examples/pubsub/server.rs
+++ b/capnp-rpc/examples/pubsub/server.rs
@@ -167,7 +167,10 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             subscriber.requests_in_flight += 1;
                             let mut request = subscriber.client.push_message_request();
                             request.get().set_message(
-                            &format!("system time is: {:?}", ::std::time::SystemTime::now())[..])?;
+                                (&format!("system time is: {:?}", ::std::time::SystemTime::now())
+                                    [..])
+                                    .into(),
+                            )?;
                             let subscribers2 = subscribers1.clone();
                             tokio::task::spawn_local(request.send().promise.map(
                                 move |r| match r {

--- a/capnp-rpc/src/rpc_capnp.rs
+++ b/capnp-rpc/src/rpc_capnp.rs
@@ -8008,6 +8008,15 @@ pub mod exception {
             }
         }
         #[inline]
+        pub fn get_reason_as_bytes(self) -> ::capnp::Result<&'a [u8]> {
+            ::core::result::Result::Ok(::capnp::text::Reader::as_bytes(
+                ::capnp::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(0),
+                    ::core::option::Option::None,
+                )?,
+            ))
+        }
+        #[inline]
         pub fn has_reason(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
@@ -8035,6 +8044,15 @@ pub mod exception {
                 ::core::result::Result::Ok(r) => ::capnp::text::Reader::to_str(r),
                 ::core::result::Result::Err(e) => ::core::result::Result::Err(e),
             }
+        }
+        #[inline]
+        pub fn get_trace_as_bytes(self) -> ::capnp::Result<&'a [u8]> {
+            ::core::result::Result::Ok(::capnp::text::Reader::as_bytes(
+                ::capnp::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(1),
+                    ::core::option::Option::None,
+                )?,
+            ))
         }
         #[inline]
         pub fn has_trace(&self) -> bool {

--- a/capnp-rpc/src/rpc_capnp.rs
+++ b/capnp-rpc/src/rpc_capnp.rs
@@ -7998,11 +7998,14 @@ pub mod exception {
             self.reader.total_size()
         }
         #[inline]
-        pub fn get_reason(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-            ::capnp::traits::FromPointerReader::get_from_pointer(
+        pub fn get_reason(self) -> ::capnp::Result<&'a str> {
+            match ::capnp::traits::FromPointerReader::get_from_pointer(
                 &self.reader.get_pointer_field(0),
                 ::core::option::Option::None,
-            )
+            ) {
+                ::core::result::Result::Ok(r) => ::capnp::text::Reader::to_str(r),
+                ::core::result::Result::Err(e) => ::core::result::Result::Err(e),
+            }
         }
         #[inline]
         pub fn has_reason(&self) -> bool {
@@ -8024,11 +8027,14 @@ pub mod exception {
             ::core::convert::TryInto::try_into(self.reader.get_data_field::<u16>(2))
         }
         #[inline]
-        pub fn get_trace(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-            ::capnp::traits::FromPointerReader::get_from_pointer(
+        pub fn get_trace(self) -> ::capnp::Result<&'a str> {
+            match ::capnp::traits::FromPointerReader::get_from_pointer(
                 &self.reader.get_pointer_field(1),
                 ::core::option::Option::None,
-            )
+            ) {
+                ::core::result::Result::Ok(r) => ::capnp::text::Reader::to_str(r),
+                ::core::result::Result::Err(e) => ::core::result::Result::Err(e),
+            }
         }
         #[inline]
         pub fn has_trace(&self) -> bool {
@@ -8130,7 +8136,7 @@ pub mod exception {
             )
         }
         #[inline]
-        pub fn set_reason(&mut self, value: ::capnp::text::Reader<'_>) {
+        pub fn set_reason(&mut self, value: &str) {
             self.builder.reborrow().get_pointer_field(0).set_text(value);
         }
         #[inline]
@@ -8176,7 +8182,7 @@ pub mod exception {
             )
         }
         #[inline]
-        pub fn set_trace(&mut self, value: ::capnp::text::Reader<'_>) {
+        pub fn set_trace(&mut self, value: &str) {
             self.builder.reborrow().get_pointer_field(1).set_text(value);
         }
         #[inline]

--- a/capnp/src/dynamic_list.rs
+++ b/capnp/src/dynamic_list.rs
@@ -303,7 +303,7 @@ impl<'a> Builder<'a> {
                 .builder
                 .reborrow()
                 .get_pointer_element(index)
-                .set_text(t)),
+                .set_text(t.to_str()?)),
             (TypeVariant::Data, dynamic_value::Reader::Data(d)) => Ok(self
                 .builder
                 .reborrow()

--- a/capnp/src/dynamic_struct.rs
+++ b/capnp/src/dynamic_struct.rs
@@ -107,7 +107,7 @@ impl<'a> Reader<'a> {
                         // If the type is a generic, then the default value
                         // is always an empty AnyPointer. Ignore that case.
                         let t1 = if let (true, value::Text(t)) = (p.is_null(), dval) {
-                            t?
+                            t?.into()
                         } else {
                             p.get_text(None)?
                         };
@@ -489,7 +489,7 @@ impl<'a> Builder<'a> {
                     }
                     (TypeVariant::Text, dynamic_value::Reader::Text(tv), _) => {
                         let mut p = self.builder.reborrow().get_pointer_field(offset);
-                        p.set_text(tv);
+                        p.set_text(tv.to_str()?);
                         Ok(())
                     }
                     (TypeVariant::Data, dynamic_value::Reader::Data(v), _) => {

--- a/capnp/src/dynamic_value.rs
+++ b/capnp/src/dynamic_value.rs
@@ -2,6 +2,7 @@
 
 use crate::introspect::{self, TypeVariant};
 use crate::schema_capnp::value;
+use crate::text::new_reader;
 use crate::Result;
 use crate::{dynamic_list, dynamic_struct};
 
@@ -45,7 +46,7 @@ impl<'a> Reader<'a> {
             (value::Float32(x), _) => Ok(Reader::Float32(x)),
             (value::Float64(x), _) => Ok(Reader::Float64(x)),
             (value::Enum(d), TypeVariant::Enum(e)) => Ok(Reader::Enum(Enum::new(d, e.into()))),
-            (value::Text(t), _) => Ok(Reader::Text(t?)),
+            (value::Text(t), _) => Ok(Reader::Text(t?.into())),
             (value::Data(d), _) => Ok(Reader::Data(d?)),
             (value::Struct(d), TypeVariant::Struct(schema)) => Ok(Reader::Struct(
                 dynamic_struct::Reader::new(d.reader.get_struct(None)?, schema.into()),
@@ -73,6 +74,12 @@ impl<'a> Reader<'a> {
 impl<'a> From<()> for Reader<'a> {
     fn from((): ()) -> Reader<'a> {
         Reader::Void
+    }
+}
+
+impl<'a> From<&'a str> for Reader<'a> {
+    fn from(s: &'a str) -> Reader<'a> {
+        Reader::Text(new_reader(s))
     }
 }
 

--- a/capnp/src/private/layout.rs
+++ b/capnp/src/private/layout.rs
@@ -2615,7 +2615,7 @@ mod wire_helpers {
     ) -> Result<text::Reader<'a>> {
         if (*reff).is_null() {
             match default {
-                None => return Ok(""),
+                None => return Ok("".into()),
                 Some(d) => {
                     reff = d.as_ptr() as *const WirePointer;
                     arena = &super::NULL_ARENA;
@@ -2661,7 +2661,9 @@ mod wire_helpers {
             ));
         }
 
-        text::new_reader(slice::from_raw_parts(str_ptr, size as usize - 1))
+        Ok(text::Reader {
+            reader: slice::from_raw_parts(str_ptr, size as usize - 1),
+        })
     }
 
     #[inline]

--- a/capnp/src/schema_capnp.rs
+++ b/capnp/src/schema_capnp.rs
@@ -108,11 +108,14 @@ pub mod node {
             self.reader.get_data_field::<u64>(0)
         }
         #[inline]
-        pub fn get_display_name(self) -> crate::Result<crate::text::Reader<'a>> {
-            crate::traits::FromPointerReader::get_from_pointer(
+        pub fn get_display_name(self) -> crate::Result<&'a str> {
+            match crate::traits::FromPointerReader::get_from_pointer(
                 &self.reader.get_pointer_field(0),
                 ::core::option::Option::None,
-            )
+            ) {
+                ::core::result::Result::Ok(r) => crate::text::Reader::to_str(r),
+                ::core::result::Result::Err(e) => ::core::result::Result::Err(e),
+            }
         }
         #[inline]
         pub fn has_display_name(&self) -> bool {
@@ -287,7 +290,7 @@ pub mod node {
             )
         }
         #[inline]
-        pub fn set_display_name(&mut self, value: crate::text::Reader<'_>) {
+        pub fn set_display_name(&mut self, value: &str) {
             self.builder.reborrow().get_pointer_field(0).set_text(value);
         }
         #[inline]
@@ -886,11 +889,14 @@ pub mod node {
                 self.reader.total_size()
             }
             #[inline]
-            pub fn get_name(self) -> crate::Result<crate::text::Reader<'a>> {
-                crate::traits::FromPointerReader::get_from_pointer(
+            pub fn get_name(self) -> crate::Result<&'a str> {
+                match crate::traits::FromPointerReader::get_from_pointer(
                     &self.reader.get_pointer_field(0),
                     ::core::option::Option::None,
-                )
+                ) {
+                    ::core::result::Result::Ok(r) => crate::text::Reader::to_str(r),
+                    ::core::result::Result::Err(e) => ::core::result::Result::Err(e),
+                }
             }
             #[inline]
             pub fn has_name(&self) -> bool {
@@ -992,7 +998,7 @@ pub mod node {
                 )
             }
             #[inline]
-            pub fn set_name(&mut self, value: crate::text::Reader<'_>) {
+            pub fn set_name(&mut self, value: &str) {
                 self.builder.reborrow().get_pointer_field(0).set_text(value);
             }
             #[inline]
@@ -1176,11 +1182,14 @@ pub mod node {
                 self.reader.total_size()
             }
             #[inline]
-            pub fn get_name(self) -> crate::Result<crate::text::Reader<'a>> {
-                crate::traits::FromPointerReader::get_from_pointer(
+            pub fn get_name(self) -> crate::Result<&'a str> {
+                match crate::traits::FromPointerReader::get_from_pointer(
                     &self.reader.get_pointer_field(0),
                     ::core::option::Option::None,
-                )
+                ) {
+                    ::core::result::Result::Ok(r) => crate::text::Reader::to_str(r),
+                    ::core::result::Result::Err(e) => ::core::result::Result::Err(e),
+                }
             }
             #[inline]
             pub fn has_name(&self) -> bool {
@@ -1286,7 +1295,7 @@ pub mod node {
                 )
             }
             #[inline]
-            pub fn set_name(&mut self, value: crate::text::Reader<'_>) {
+            pub fn set_name(&mut self, value: &str) {
                 self.builder.reborrow().get_pointer_field(0).set_text(value);
             }
             #[inline]
@@ -1498,11 +1507,14 @@ pub mod node {
                 self.reader.get_data_field::<u64>(0)
             }
             #[inline]
-            pub fn get_doc_comment(self) -> crate::Result<crate::text::Reader<'a>> {
-                crate::traits::FromPointerReader::get_from_pointer(
+            pub fn get_doc_comment(self) -> crate::Result<&'a str> {
+                match crate::traits::FromPointerReader::get_from_pointer(
                     &self.reader.get_pointer_field(0),
                     ::core::option::Option::None,
-                )
+                ) {
+                    ::core::result::Result::Ok(r) => crate::text::Reader::to_str(r),
+                    ::core::result::Result::Err(e) => ::core::result::Result::Err(e),
+                }
             }
             #[inline]
             pub fn has_doc_comment(&self) -> bool {
@@ -1630,7 +1642,7 @@ pub mod node {
                 )
             }
             #[inline]
-            pub fn set_doc_comment(&mut self, value: crate::text::Reader<'_>) {
+            pub fn set_doc_comment(&mut self, value: &str) {
                 self.builder.reborrow().get_pointer_field(0).set_text(value);
             }
             #[inline]
@@ -1904,11 +1916,14 @@ pub mod node {
                     self.reader.total_size()
                 }
                 #[inline]
-                pub fn get_doc_comment(self) -> crate::Result<crate::text::Reader<'a>> {
-                    crate::traits::FromPointerReader::get_from_pointer(
+                pub fn get_doc_comment(self) -> crate::Result<&'a str> {
+                    match crate::traits::FromPointerReader::get_from_pointer(
                         &self.reader.get_pointer_field(0),
                         ::core::option::Option::None,
-                    )
+                    ) {
+                        ::core::result::Result::Ok(r) => crate::text::Reader::to_str(r),
+                        ::core::result::Result::Err(e) => ::core::result::Result::Err(e),
+                    }
                 }
                 #[inline]
                 pub fn has_doc_comment(&self) -> bool {
@@ -2015,7 +2030,7 @@ pub mod node {
                     )
                 }
                 #[inline]
-                pub fn set_doc_comment(&mut self, value: crate::text::Reader<'_>) {
+                pub fn set_doc_comment(&mut self, value: &str) {
                     self.builder.reborrow().get_pointer_field(0).set_text(value);
                 }
                 #[inline]
@@ -4411,11 +4426,14 @@ pub mod field {
             self.reader.total_size()
         }
         #[inline]
-        pub fn get_name(self) -> crate::Result<crate::text::Reader<'a>> {
-            crate::traits::FromPointerReader::get_from_pointer(
+        pub fn get_name(self) -> crate::Result<&'a str> {
+            match crate::traits::FromPointerReader::get_from_pointer(
                 &self.reader.get_pointer_field(0),
                 ::core::option::Option::None,
-            )
+            ) {
+                ::core::result::Result::Ok(r) => crate::text::Reader::to_str(r),
+                ::core::result::Result::Err(e) => ::core::result::Result::Err(e),
+            }
         }
         #[inline]
         pub fn has_name(&self) -> bool {
@@ -4548,7 +4566,7 @@ pub mod field {
             )
         }
         #[inline]
-        pub fn set_name(&mut self, value: crate::text::Reader<'_>) {
+        pub fn set_name(&mut self, value: &str) {
             self.builder.reborrow().get_pointer_field(0).set_text(value);
         }
         #[inline]
@@ -5923,11 +5941,14 @@ pub mod enumerant {
             self.reader.total_size()
         }
         #[inline]
-        pub fn get_name(self) -> crate::Result<crate::text::Reader<'a>> {
-            crate::traits::FromPointerReader::get_from_pointer(
+        pub fn get_name(self) -> crate::Result<&'a str> {
+            match crate::traits::FromPointerReader::get_from_pointer(
                 &self.reader.get_pointer_field(0),
                 ::core::option::Option::None,
-            )
+            ) {
+                ::core::result::Result::Ok(r) => crate::text::Reader::to_str(r),
+                ::core::result::Result::Err(e) => ::core::result::Result::Err(e),
+            }
         }
         #[inline]
         pub fn has_name(&self) -> bool {
@@ -6044,7 +6065,7 @@ pub mod enumerant {
             )
         }
         #[inline]
-        pub fn set_name(&mut self, value: crate::text::Reader<'_>) {
+        pub fn set_name(&mut self, value: &str) {
             self.builder.reborrow().get_pointer_field(0).set_text(value);
         }
         #[inline]
@@ -6633,11 +6654,14 @@ pub mod method {
             self.reader.total_size()
         }
         #[inline]
-        pub fn get_name(self) -> crate::Result<crate::text::Reader<'a>> {
-            crate::traits::FromPointerReader::get_from_pointer(
+        pub fn get_name(self) -> crate::Result<&'a str> {
+            match crate::traits::FromPointerReader::get_from_pointer(
                 &self.reader.get_pointer_field(0),
                 ::core::option::Option::None,
-            )
+            ) {
+                ::core::result::Result::Ok(r) => crate::text::Reader::to_str(r),
+                ::core::result::Result::Err(e) => ::core::result::Result::Err(e),
+            }
         }
         #[inline]
         pub fn has_name(&self) -> bool {
@@ -6799,7 +6823,7 @@ pub mod method {
             )
         }
         #[inline]
-        pub fn set_name(&mut self, value: crate::text::Reader<'_>) {
+        pub fn set_name(&mut self, value: &str) {
             self.builder.reborrow().get_pointer_field(0).set_text(value);
         }
         #[inline]
@@ -11653,10 +11677,13 @@ pub mod value {
                 10 => ::core::result::Result::Ok(Float32(self.reader.get_data_field::<f32>(1))),
                 11 => ::core::result::Result::Ok(Float64(self.reader.get_data_field::<f64>(1))),
                 12 => ::core::result::Result::Ok(Text(
-                    crate::traits::FromPointerReader::get_from_pointer(
+                    match crate::traits::FromPointerReader::get_from_pointer(
                         &self.reader.get_pointer_field(0),
                         ::core::option::Option::None,
-                    ),
+                    ) {
+                        ::core::result::Result::Ok(r) => crate::text::Reader::to_str(r),
+                        ::core::result::Result::Err(e) => ::core::result::Result::Err(e),
+                    },
                 )),
                 13 => ::core::result::Result::Ok(Data(
                     crate::traits::FromPointerReader::get_from_pointer(
@@ -11823,7 +11850,7 @@ pub mod value {
             self.builder.set_data_field::<f64>(1, value);
         }
         #[inline]
-        pub fn set_text(&mut self, value: crate::text::Reader<'_>) {
+        pub fn set_text(&mut self, value: &str) {
             self.builder.set_data_field::<u16>(0, 12);
             self.builder.reborrow().get_pointer_field(0).set_text(value);
         }
@@ -12332,7 +12359,7 @@ pub mod value {
         AnyPointer(A4),
     }
     pub type WhichReader<'a> = Which<
-        crate::Result<crate::text::Reader<'a>>,
+        crate::Result<&'a str>,
         crate::Result<crate::data::Reader<'a>>,
         crate::any_pointer::Reader<'a>,
         crate::any_pointer::Reader<'a>,
@@ -13811,11 +13838,14 @@ pub mod code_generator_request {
                 self.reader.get_data_field::<u64>(0)
             }
             #[inline]
-            pub fn get_filename(self) -> crate::Result<crate::text::Reader<'a>> {
-                crate::traits::FromPointerReader::get_from_pointer(
+            pub fn get_filename(self) -> crate::Result<&'a str> {
+                match crate::traits::FromPointerReader::get_from_pointer(
                     &self.reader.get_pointer_field(0),
                     ::core::option::Option::None,
-                )
+                ) {
+                    ::core::result::Result::Ok(r) => crate::text::Reader::to_str(r),
+                    ::core::result::Result::Err(e) => ::core::result::Result::Err(e),
+                }
             }
             #[inline]
             pub fn has_filename(&self) -> bool {
@@ -13943,7 +13973,7 @@ pub mod code_generator_request {
                 )
             }
             #[inline]
-            pub fn set_filename(&mut self, value: crate::text::Reader<'_>) {
+            pub fn set_filename(&mut self, value: &str) {
                 self.builder.reborrow().get_pointer_field(0).set_text(value);
             }
             #[inline]
@@ -14223,11 +14253,14 @@ pub mod code_generator_request {
                     self.reader.get_data_field::<u64>(0)
                 }
                 #[inline]
-                pub fn get_name(self) -> crate::Result<crate::text::Reader<'a>> {
-                    crate::traits::FromPointerReader::get_from_pointer(
+                pub fn get_name(self) -> crate::Result<&'a str> {
+                    match crate::traits::FromPointerReader::get_from_pointer(
                         &self.reader.get_pointer_field(0),
                         ::core::option::Option::None,
-                    )
+                    ) {
+                        ::core::result::Result::Ok(r) => crate::text::Reader::to_str(r),
+                        ::core::result::Result::Err(e) => ::core::result::Result::Err(e),
+                    }
                 }
                 #[inline]
                 pub fn has_name(&self) -> bool {
@@ -14342,7 +14375,7 @@ pub mod code_generator_request {
                     )
                 }
                 #[inline]
-                pub fn set_name(&mut self, value: crate::text::Reader<'_>) {
+                pub fn set_name(&mut self, value: &str) {
                     self.builder.reborrow().get_pointer_field(0).set_text(value);
                 }
                 #[inline]

--- a/capnp/src/schema_capnp.rs
+++ b/capnp/src/schema_capnp.rs
@@ -118,6 +118,15 @@ pub mod node {
             }
         }
         #[inline]
+        pub fn get_display_name_as_bytes(self) -> crate::Result<&'a [u8]> {
+            ::core::result::Result::Ok(crate::text::Reader::as_bytes(
+                crate::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(0),
+                    ::core::option::Option::None,
+                )?,
+            ))
+        }
+        #[inline]
         pub fn has_display_name(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
@@ -899,6 +908,15 @@ pub mod node {
                 }
             }
             #[inline]
+            pub fn get_name_as_bytes(self) -> crate::Result<&'a [u8]> {
+                ::core::result::Result::Ok(crate::text::Reader::as_bytes(
+                    crate::traits::FromPointerReader::get_from_pointer(
+                        &self.reader.get_pointer_field(0),
+                        ::core::option::Option::None,
+                    )?,
+                ))
+            }
+            #[inline]
             pub fn has_name(&self) -> bool {
                 !self.reader.get_pointer_field(0).is_null()
             }
@@ -1190,6 +1208,15 @@ pub mod node {
                     ::core::result::Result::Ok(r) => crate::text::Reader::to_str(r),
                     ::core::result::Result::Err(e) => ::core::result::Result::Err(e),
                 }
+            }
+            #[inline]
+            pub fn get_name_as_bytes(self) -> crate::Result<&'a [u8]> {
+                ::core::result::Result::Ok(crate::text::Reader::as_bytes(
+                    crate::traits::FromPointerReader::get_from_pointer(
+                        &self.reader.get_pointer_field(0),
+                        ::core::option::Option::None,
+                    )?,
+                ))
             }
             #[inline]
             pub fn has_name(&self) -> bool {
@@ -1515,6 +1542,15 @@ pub mod node {
                     ::core::result::Result::Ok(r) => crate::text::Reader::to_str(r),
                     ::core::result::Result::Err(e) => ::core::result::Result::Err(e),
                 }
+            }
+            #[inline]
+            pub fn get_doc_comment_as_bytes(self) -> crate::Result<&'a [u8]> {
+                ::core::result::Result::Ok(crate::text::Reader::as_bytes(
+                    crate::traits::FromPointerReader::get_from_pointer(
+                        &self.reader.get_pointer_field(0),
+                        ::core::option::Option::None,
+                    )?,
+                ))
             }
             #[inline]
             pub fn has_doc_comment(&self) -> bool {
@@ -1924,6 +1960,15 @@ pub mod node {
                         ::core::result::Result::Ok(r) => crate::text::Reader::to_str(r),
                         ::core::result::Result::Err(e) => ::core::result::Result::Err(e),
                     }
+                }
+                #[inline]
+                pub fn get_doc_comment_as_bytes(self) -> crate::Result<&'a [u8]> {
+                    ::core::result::Result::Ok(crate::text::Reader::as_bytes(
+                        crate::traits::FromPointerReader::get_from_pointer(
+                            &self.reader.get_pointer_field(0),
+                            ::core::option::Option::None,
+                        )?,
+                    ))
                 }
                 #[inline]
                 pub fn has_doc_comment(&self) -> bool {
@@ -4436,6 +4481,15 @@ pub mod field {
             }
         }
         #[inline]
+        pub fn get_name_as_bytes(self) -> crate::Result<&'a [u8]> {
+            ::core::result::Result::Ok(crate::text::Reader::as_bytes(
+                crate::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(0),
+                    ::core::option::Option::None,
+                )?,
+            ))
+        }
+        #[inline]
         pub fn has_name(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
@@ -5951,6 +6005,15 @@ pub mod enumerant {
             }
         }
         #[inline]
+        pub fn get_name_as_bytes(self) -> crate::Result<&'a [u8]> {
+            ::core::result::Result::Ok(crate::text::Reader::as_bytes(
+                crate::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(0),
+                    ::core::option::Option::None,
+                )?,
+            ))
+        }
+        #[inline]
         pub fn has_name(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
@@ -6662,6 +6725,15 @@ pub mod method {
                 ::core::result::Result::Ok(r) => crate::text::Reader::to_str(r),
                 ::core::result::Result::Err(e) => ::core::result::Result::Err(e),
             }
+        }
+        #[inline]
+        pub fn get_name_as_bytes(self) -> crate::Result<&'a [u8]> {
+            ::core::result::Result::Ok(crate::text::Reader::as_bytes(
+                crate::traits::FromPointerReader::get_from_pointer(
+                    &self.reader.get_pointer_field(0),
+                    ::core::option::Option::None,
+                )?,
+            ))
         }
         #[inline]
         pub fn has_name(&self) -> bool {
@@ -13848,6 +13920,15 @@ pub mod code_generator_request {
                 }
             }
             #[inline]
+            pub fn get_filename_as_bytes(self) -> crate::Result<&'a [u8]> {
+                ::core::result::Result::Ok(crate::text::Reader::as_bytes(
+                    crate::traits::FromPointerReader::get_from_pointer(
+                        &self.reader.get_pointer_field(0),
+                        ::core::option::Option::None,
+                    )?,
+                ))
+            }
+            #[inline]
             pub fn has_filename(&self) -> bool {
                 !self.reader.get_pointer_field(0).is_null()
             }
@@ -14261,6 +14342,15 @@ pub mod code_generator_request {
                         ::core::result::Result::Ok(r) => crate::text::Reader::to_str(r),
                         ::core::result::Result::Err(e) => ::core::result::Result::Err(e),
                     }
+                }
+                #[inline]
+                pub fn get_name_as_bytes(self) -> crate::Result<&'a [u8]> {
+                    ::core::result::Result::Ok(crate::text::Reader::as_bytes(
+                        crate::traits::FromPointerReader::get_from_pointer(
+                            &self.reader.get_pointer_field(0),
+                            ::core::option::Option::None,
+                        )?,
+                    ))
                 }
                 #[inline]
                 pub fn has_name(&self) -> bool {

--- a/capnp/src/stringify.rs
+++ b/capnp/src/stringify.rs
@@ -75,7 +75,13 @@ pub(crate) fn print(
             Some(enumerant) => formatter.write_str(cvt(enumerant.get_proto().get_name())?),
             None => formatter.write_fmt(format_args!("{}", e.get_value())),
         },
-        dynamic_value::Reader::Text(t) => formatter.write_fmt(format_args!("{t:?}")),
+        dynamic_value::Reader::Text(t) => {
+            if let Ok(s) = t.to_str() {
+                formatter.write_fmt(format_args!("{s:?}"))
+            } else {
+                print(dynamic_value::Reader::Data(t.reader), formatter, indent)
+            }
+        }
         dynamic_value::Reader::Data(d) => {
             formatter.write_str("0x\"")?;
             for b in d {

--- a/capnpc/test/dynamic.rs
+++ b/capnpc/test/dynamic.rs
@@ -79,7 +79,11 @@ fn test_unions() {
         assert_eq!("u1f1sp", w.get_proto().get_name().unwrap());
         assert_eq!(
             "foo",
-            u.get(w).unwrap().downcast::<capnp::text::Reader<'_>>()
+            u.get(w)
+                .unwrap()
+                .downcast::<capnp::text::Reader<'_>>()
+                .to_str()
+                .unwrap()
         );
     }
     {
@@ -124,6 +128,8 @@ fn test_unions() {
                 .unwrap()
                 .into_reader()
                 .downcast::<capnp::text::Reader<'_>>()
+                .to_str()
+                .unwrap()
         );
     }
     {
@@ -168,6 +174,8 @@ fn test_generics() {
         root.get_named("bar")
             .unwrap()
             .downcast::<capnp::text::Reader<'_>>()
+            .to_str()
+            .unwrap()
     );
 }
 
@@ -184,7 +192,10 @@ fn test_generic_annotation() -> ::capnp::Result<()> {
     assert_eq!(ann.get_id(), test_generics::ann::ID);
     assert_eq!(
         "foo",
-        ann.get_value()?.downcast::<capnp::text::Reader<'_>>()
+        ann.get_value()?
+            .downcast::<capnp::text::Reader<'_>>()
+            .to_str()
+            .unwrap()
     );
     Ok(())
 }

--- a/capnpc/test/test_util.rs
+++ b/capnpc/test/test_util.rs
@@ -562,6 +562,8 @@ pub fn dynamic_check_test_message(reader: capnp::dynamic_struct::Reader<'_>) {
             .get_named("textField")
             .unwrap()
             .downcast::<capnp::text::Reader<'_>>()
+            .to_str()
+            .unwrap()
     );
     assert_eq!(
         &b"bar"[..],
@@ -624,6 +626,8 @@ pub fn dynamic_check_test_message(reader: capnp::dynamic_struct::Reader<'_>) {
                 .get(0)
                 .unwrap()
                 .downcast::<capnp::text::Reader<'_>>()
+                .to_str()
+                .unwrap()
         );
         assert_eq!(
             "xyzzy",
@@ -631,6 +635,8 @@ pub fn dynamic_check_test_message(reader: capnp::dynamic_struct::Reader<'_>) {
                 .get(1)
                 .unwrap()
                 .downcast::<capnp::text::Reader<'_>>()
+                .to_str()
+                .unwrap()
         );
         assert_eq!(
             "thud",
@@ -638,6 +644,8 @@ pub fn dynamic_check_test_message(reader: capnp::dynamic_struct::Reader<'_>) {
                 .get(2)
                 .unwrap()
                 .downcast::<capnp::text::Reader<'_>>()
+                .to_str()
+                .unwrap()
         );
     }
 
@@ -681,6 +689,8 @@ pub fn dynamic_check_test_message(reader: capnp::dynamic_struct::Reader<'_>) {
                 .get_named("textField")
                 .unwrap()
                 .downcast::<capnp::text::Reader<'_>>()
+                .to_str()
+                .unwrap()
         );
         assert_eq!(
             "structlist 2",
@@ -691,6 +701,8 @@ pub fn dynamic_check_test_message(reader: capnp::dynamic_struct::Reader<'_>) {
                 .get_named("textField")
                 .unwrap()
                 .downcast::<capnp::text::Reader<'_>>()
+                .to_str()
+                .unwrap()
         );
         assert_eq!(
             "structlist 3",
@@ -701,6 +713,8 @@ pub fn dynamic_check_test_message(reader: capnp::dynamic_struct::Reader<'_>) {
                 .get_named("textField")
                 .unwrap()
                 .downcast::<capnp::text::Reader<'_>>()
+                .to_str()
+                .unwrap()
         );
     }
 }
@@ -811,6 +825,8 @@ pub fn dynamic_check_test_message_builder(mut builder: capnp::dynamic_struct::Bu
             .unwrap()
             .into_reader()
             .downcast::<capnp::text::Reader<'_>>()
+            .to_str()
+            .unwrap()
     );
     assert_eq!(
         &b"bar"[..],
@@ -899,6 +915,8 @@ pub fn dynamic_check_test_message_builder(mut builder: capnp::dynamic_struct::Bu
                 .unwrap()
                 .into_reader()
                 .downcast::<capnp::text::Reader<'_>>()
+                .to_str()
+                .unwrap()
         );
         assert_eq!(
             "xyzzy",
@@ -908,6 +926,8 @@ pub fn dynamic_check_test_message_builder(mut builder: capnp::dynamic_struct::Bu
                 .unwrap()
                 .into_reader()
                 .downcast::<capnp::text::Reader<'_>>()
+                .to_str()
+                .unwrap()
         );
         assert_eq!(
             "thud",
@@ -917,6 +937,8 @@ pub fn dynamic_check_test_message_builder(mut builder: capnp::dynamic_struct::Bu
                 .unwrap()
                 .into_reader()
                 .downcast::<capnp::text::Reader<'_>>()
+                .to_str()
+                .unwrap()
         );
     }
     {
@@ -969,6 +991,8 @@ pub fn dynamic_check_test_message_builder(mut builder: capnp::dynamic_struct::Bu
                 .unwrap()
                 .into_reader()
                 .downcast::<capnp::text::Reader<'_>>()
+                .to_str()
+                .unwrap()
         );
         assert_eq!(
             "structlist 2",
@@ -981,6 +1005,8 @@ pub fn dynamic_check_test_message_builder(mut builder: capnp::dynamic_struct::Bu
                 .unwrap()
                 .into_reader()
                 .downcast::<capnp::text::Reader<'_>>()
+                .to_str()
+                .unwrap()
         );
         assert_eq!(
             "structlist 3",
@@ -993,6 +1019,8 @@ pub fn dynamic_check_test_message_builder(mut builder: capnp::dynamic_struct::Bu
                 .unwrap()
                 .into_reader()
                 .downcast::<capnp::text::Reader<'_>>()
+                .to_str()
+                .unwrap()
         );
     }
 }


### PR DESCRIPTION
**1st commit: Make Text::Reader a wrapper around Data::Reader**
This changes the capnp::text::Reader from a &str to a wrapper around
data::Reader, which only holds bytes.
This has the benefits of:
- Moving the conversion to &str and the associated utf8 check only when
necessary, which can be a performance improvement in some cases.
- Allowing to support broken Text fields that may not hold valid UTF-8.

This holds all the changes to the capnp module. Codegen and capnpc
changes will come in a later commit, as well as exposing getting only
the bytes from a text reader from the codegen.

**2nd commit: Update codegen for text::Reader being a wrapper around data::Reader**
This here only includes the transition from the reader being a &str to a
wrapper around &[u8]. No new method is exposed.

**3rd commit: Regenerate capnp-rpc**

**4th commit: Test update to adapt to text::Reader being a wrapper around Data**

**5th commit: Add codegen to expose getter as bytes for text fields**
Exposes as getter as bytes for text fields in the codegen. This is a
secondary getter that is for now only populating anything for text
fields for readers. I have duplicated the method and trimmed it only
for texts instead of complexifying the already existent getter_text
function for the sake of clarity.

This also regenerates the corresponding rpc_capnp and schema_capnp rust
files.

**6th commit: Add tests for get _as_bytes() methods and invalid_utf8 test**
Test that we result in an error when fetching an invalid utf8 reader but
that we can still get the bytes using the _as_bytes() getter method.